### PR TITLE
Add simple inference FLOP counter to `calc_transformer_flops.py`

### DIFF
--- a/calc/calc_transformer_flops.py
+++ b/calc/calc_transformer_flops.py
@@ -70,7 +70,6 @@ def config_parser():
 
 # calculates the flops of a model given its hparams
 def calc_params(args):
-    print(args)
     assert args.topk <= args.num_experts, "You cannot route to more experts than you have!"
     assert args.num_layers % args.expert_interval == 0, "Require for simplicity that we don't have hanging dense layers"
 
@@ -83,6 +82,8 @@ def calc_params(args):
     if args.checkpoint_activations:
         iter_factor += 1
     # If inference-only, no bwd pass or activation ckpting necessary
+    # This assumes simply running a single forward pass ('prefill' stage of decoding) and no generated tokens.
+    # Or, if using a KV cache, this flop count will also be accurate.
     if args.infer:
         iter_factor = 1
 

--- a/calc/calc_transformer_flops.py
+++ b/calc/calc_transformer_flops.py
@@ -83,7 +83,6 @@ def calc_params(args):
         iter_factor += 1
     # If inference-only, no bwd pass or activation ckpting necessary
     # This assumes simply running a single forward pass ('prefill' stage of decoding) and no generated tokens.
-    # Or, if using a KV cache, this flop count will also be accurate.
     if args.infer:
         iter_factor = 1
 

--- a/calc/calc_transformer_flops.py
+++ b/calc/calc_transformer_flops.py
@@ -63,11 +63,14 @@ def config_parser():
                         action='store_false',
                         help='Whether Megatron-style activation checkpointing is being used',
                         dest='checkpoint_activations')
+    parser.add_argument("--infer", "-i", 
+                        action='store_true',
+                        help='Pass to calculate FLOPs for inference-only workload (no backward pass)')
     return parser
 
 # calculates the flops of a model given its hparams
 def calc_params(args):
-
+    print(args)
     assert args.topk <= args.num_experts, "You cannot route to more experts than you have!"
     assert args.num_layers % args.expert_interval == 0, "Require for simplicity that we don't have hanging dense layers"
 
@@ -79,6 +82,9 @@ def calc_params(args):
     iter_factor = 3
     if args.checkpoint_activations:
         iter_factor += 1
+    # If inference-only, no bwd pass or activation ckpting necessary
+    if args.infer:
+        iter_factor = 1
 
     qkv_flops = int(iter_factor * 2 * (1 + 2 * args.kv_size_ratio) * args.num_layers * args.tokens * args.hidden_size * args.hidden_size)
     attention_matrix_flops = iter_factor * 2 * args.num_layers * args.tokens * args.sequence_length * args.hidden_size

--- a/calc/calc_transformer_flops.py
+++ b/calc/calc_transformer_flops.py
@@ -82,7 +82,7 @@ def calc_params(args):
     if args.checkpoint_activations:
         iter_factor += 1
     # If inference-only, no bwd pass or activation ckpting necessary
-    # This assumes simply running a single forward pass ('prefill' stage of decoding) and no generated tokens.
+    # This assumes simply running a single forward pass ('prefill' stage of decoding) and no subsequent autoregressively generated tokens.
     if args.infer:
         iter_factor = 1
 


### PR DESCRIPTION
Output without `--infer` (same as before this PR):
```
python calc/calc_transformer_flops.py 

Example with Fairseq-MoE 15B: python calc_transformer_flops.py -l 12 -hs 768 --moe -e 512
Example with GPT-3 175B: python calc_transformer_flops.py -l 96 -hs 12288
Namespace(vocab_size=51200, hidden_size=6144, sequence_length=2048, num_layers=44, kv_size_ratio=1.0, moe=False, num_experts=128, expert_interval=2, topk=1, batch_size=1, tokens=300000000000.0, checkpoint_activations=True, infer=False)
Calculating number of FLOPs with training configuration: {'vocab_size': 51200, 'hidden_size': 6144, 'sequence_length': 2048, 'num_layers': 44, 'kv_size_ratio': 1.0, 'moe': False, 'num_experts': 128, 'expert_interval': 2, 'topk': 1, 'batch_size': 1, 'tokens': 300000000000.0, 'checkpoint_activations': True, 'infer': False}

QKV FLOPs: 11.96 ZFLOPs
Attention Matrix FLOPs: 1.33 ZFLOPs
Attention Over Values FLOPs: 1.33 ZFLOPs
Linear Projection FLOPs: 3.99 ZFLOPs
FFN FLOPs: 31.89 ZFLOPs
Embedding FLOPs: 566.23 EFLOPs
Total FLOPs for the Model: 51.06 ZFLOPs
```

Output with `--infer`:

```
> python calc/calc_transformer_flops.py --infer

Example with Fairseq-MoE 15B: python calc_transformer_flops.py -l 12 -hs 768 --moe -e 512
Example with GPT-3 175B: python calc_transformer_flops.py -l 96 -hs 12288
Namespace(vocab_size=51200, hidden_size=6144, sequence_length=2048, num_layers=44, kv_size_ratio=1.0, moe=False, num_experts=128, expert_interval=2, topk=1, batch_size=1, tokens=300000000000.0, checkpoint_activations=True, infer=True)
Calculating number of FLOPs with training configuration: {'vocab_size': 51200, 'hidden_size': 6144, 'sequence_length': 2048, 'num_layers': 44, 'kv_size_ratio': 1.0, 'moe': False, 'num_experts': 128, 'expert_interval': 2, 'topk': 1, 'batch_size': 1, 'tokens': 300000000000.0, 'checkpoint_activations': True, 'infer': True}

QKV FLOPs: 2.99 ZFLOPs
Attention Matrix FLOPs: 332.19 EFLOPs
Attention Over Values FLOPs: 332.19 EFLOPs
Linear Projection FLOPs: 996.57 EFLOPs
FFN FLOPs: 7.97 ZFLOPs
Embedding FLOPs: 566.23 EFLOPs
Total FLOPs for the Model: 13.19 ZFLOPs
```

inference cuts flop counts to 1/3 (if no activation ckpting) or 1/4 (if activation ckpting) as expected. 

This is a very naive way of calculating "true" inference costs, though may hopefully be useful, especially if one only were wanting to run only a forward pass e.g. to get perplexity / loglikelihoods / embeddings on a dataset of X tokens.