### PR TITLE
benchmark header: add gpu info

### DIFF
--- a/benchmarks/sizing/utils.py
+++ b/benchmarks/sizing/utils.py
@@ -23,6 +23,7 @@ Benchmark started on {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())}
 
 ** Platform:
 {" ".join(platform.uname())}
+{torch.cuda.get_device_properties(torch.device('cuda'))}
 
 ** Critical component versions:
 torch={torch.__version__}, cuda={torch.version.cuda}, nccl={torch.cuda.nccl.version()}


### PR DESCRIPTION
When creating the info-header I forgot the most important part - the GPU properties

Now it'll add:
```
_CudaDeviceProperties(name='NVIDIA A100 80GB PCIe', major=8, minor=0, total_memory=81037MB, multi_processor_count=108)
```
so if you look at the log file months later you'd know what it was created with.

Please let me know if there is any other meta info that would be useful here.