### PR TITLE
Add MLP Linears Argument

### DIFF
--- a/calc/README.md
+++ b/calc/README.md
@@ -20,7 +20,8 @@ Currently, scripts are entirely self-contained. This is for the dual purpose of:
 ```
 Example with Fairseq-MoE 15B: python calc_transformer_flops.py -l 12 -hs 768 --moe -e 512
 Example with GPT-3 175B: python calc_transformer_flops.py -l 96 -hs 12288
-usage: calc_transformer_flops.py [-h] [--vocab-size VOCAB_SIZE] [--hidden-size HIDDEN_SIZE] [--sequence-length SEQUENCE_LENGTH] [--num-layers NUM_LAYERS] [--kv-size-ratio KV_SIZE_RATIO] [--moe] [--num-experts NUM_EXPERTS] [--expert-interval EXPERT_INTERVAL] [--topk TOPK] [--swiglu] [--batch-size BATCH_SIZE] [--tokens TOKENS] [--no-checkpoint-activations]
+usage: calc_transformer_flops.py [-h] [--vocab-size VOCAB_SIZE] [--hidden-size HIDDEN_SIZE] [--sequence-length SEQUENCE_LENGTH] [--num-layers NUM_LAYERS] [--kv-size-ratio KV_SIZE_RATIO] [--moe] [--num-experts NUM_EXPERTS] [--expert-interval EXPERT_INTERVAL]
+                                 [--topk TOPK] [--swiglu] [--batch-size BATCH_SIZE] [--tokens TOKENS] [--no-checkpoint-activations] [--ffn-expansion-factor FFN_EXPANSION_FACTOR] [--num-mlp-linears NUM_MLP_LINEARS] [--infer]
 
 options:
   -h, --help            show this help message and exit
@@ -46,6 +47,11 @@ options:
   --tokens TOKENS       Number of tokens you are training over
   --no-checkpoint-activations, -ca
                         Whether Megatron-style activation checkpointing is being used
+  --ffn-expansion-factor FFN_EXPANSION_FACTOR, -ff FFN_EXPANSION_FACTOR
+                        How much the MLP hidden size expands
+  --num-mlp-linears NUM_MLP_LINEARS, -nl NUM_MLP_LINEARS
+                        How many linear layers per MLP block
+  --infer, -i           Pass to calculate FLOPs for inference-only workload (no backward pass)
 ```
 
 
@@ -56,8 +62,8 @@ options:
 ```
 Example with Fairseq-MoE 15B: python calc_transformer_params.py -l 12 -hs 768 --moe -e 512
 Example with GPT-3 175B: python calc_transformer_params.py -l 96 -hs 12288
-usage: calc_transformer_params.py [-h] [--vocab-size VOCAB_SIZE] [--tied-embeddings] [--hidden-size HIDDEN_SIZE] [--sequence-length SEQUENCE_LENGTH] [--num-layers NUM_LAYERS] [--moe] [--num-experts NUM_EXPERTS]
-                                  [--expert-interval EXPERT_INTERVAL] [--topk TOPK] [--ffn-expansion-factor FFN_EXPANSION_FACTOR] [--kv-size-ratio KV_SIZE_RATIO]
+usage: calc_transformer_params.py [-h] [--vocab-size VOCAB_SIZE] [--tied-embeddings] [--hidden-size HIDDEN_SIZE] [--sequence-length SEQUENCE_LENGTH] [--num-layers NUM_LAYERS] [--moe] [--num-experts NUM_EXPERTS] [--expert-interval EXPERT_INTERVAL] [--topk TOPK]
+                                  [--ffn-expansion-factor FFN_EXPANSION_FACTOR] [--num-mlp-linears NUM_MLP_LINEARS] [--kv-size-ratio KV_SIZE_RATIO]
 
 options:
   -h, --help            show this help message and exit
@@ -78,6 +84,8 @@ options:
   --topk TOPK, -t TOPK  Top k routing for MoE
   --ffn-expansion-factor FFN_EXPANSION_FACTOR, -ff FFN_EXPANSION_FACTOR
                         How much the MLP hidden size expands
+  --num-mlp-linears NUM_MLP_LINEARS, -nl NUM_MLP_LINEARS
+                        How many linear layers per MLP block
   --kv-size-ratio KV_SIZE_RATIO, -kv KV_SIZE_RATIO
                         What fraction of num. query heads is num. key/value heads
 ```
@@ -94,9 +102,9 @@ Example with default 20B: python calc_transformer_mem.py --num-layers=44 --seque
 
 usage: calc_transformer_mem.py [-h] [--num-gpus NUM_GPUS] [--tensor-parallel-size TENSOR_PARALLEL_SIZE] [--pipeline-parallel-size PIPELINE_PARALLEL_SIZE] [--partition-activations] [--zero-stage {0,1,2,3}] [--zero-allgather-bucket-size ZERO_ALLGATHER_BUCKET_SIZE]
                                [--zero3-max-live-params ZERO3_MAX_LIVE_PARAMS] [--checkpoint-activations] [--batch-size-per-gpu BATCH_SIZE_PER_GPU] [--sequence-length SEQUENCE_LENGTH] [--vocab-size VOCAB_SIZE] [--hidden-size HIDDEN_SIZE]
-                               [--num-attention-heads NUM_ATTENTION_HEADS] [--num-layers NUM_LAYERS] [--ffn-expansion-factor FFN_EXPANSION_FACTOR] [--infer] [--kv-size-ratio KV_SIZE_RATIO] [--output-tokens OUTPUT_TOKENS] [--disable-mixed-precision]
-                               [--high-prec-bytes-per-val HIGH_PREC_BYTES_PER_VAL] [--low-prec-bytes-per-val LOW_PREC_BYTES_PER_VAL] [--bytes-per-grad-ele BYTES_PER_GRAD_ELE] [--num-experts NUM_EXPERTS] [--expert-parallelism EXPERT_PARALLELISM]
-                               [--misc-mem-gib MISC_MEM_GIB]
+                               [--num-attention-heads NUM_ATTENTION_HEADS] [--num-layers NUM_LAYERS] [--ffn-expansion-factor FFN_EXPANSION_FACTOR] [--num-mlp-linears NUM_MLP_LINEARS] [--infer] [--kv-size-ratio KV_SIZE_RATIO] [--output-tokens OUTPUT_TOKENS]
+                               [--disable-mixed-precision] [--high-prec-bytes-per-val HIGH_PREC_BYTES_PER_VAL] [--low-prec-bytes-per-val LOW_PREC_BYTES_PER_VAL] [--bytes-per-grad-ele BYTES_PER_GRAD_ELE] [--num-experts NUM_EXPERTS]
+                               [--expert-parallelism EXPERT_PARALLELISM] [--misc-mem-gib MISC_MEM_GIB]
 
 options:
   -h, --help            show this help message and exit
@@ -129,6 +137,8 @@ options:
                         Number of transformer layers used in model
   --ffn-expansion-factor FFN_EXPANSION_FACTOR, -ff FFN_EXPANSION_FACTOR
                         How much the MLP hidden size expands
+  --num-mlp-linears NUM_MLP_LINEARS, -nl NUM_MLP_LINEARS
+                        How many linear layers per MLP block
   --infer               whether we're doing inference
   --kv-size-ratio KV_SIZE_RATIO, -kv KV_SIZE_RATIO
                         Ratio of total query heads to key/value heads. 1.0 for MHA, 1/num_attention_heads for MQA.

--- a/calc/calc_transformer_flops.py
+++ b/calc/calc_transformer_flops.py
@@ -66,13 +66,21 @@ def config_parser():
                         action='store_false',
                         help='Whether Megatron-style activation checkpointing is being used',
                         dest='checkpoint_activations')
+    parser.add_argument("--ffn-expansion-factor", "-ff",
+                        type=int,
+                        default=4,
+                        help='How much the MLP hidden size expands')
+    parser.add_argument("--num-mlp-linears", "-nl",
+                        type=int,
+                        default=2,
+                        help='How many linear layers per MLP block')
     parser.add_argument("--infer", "-i", 
                         action='store_true',
                         help='Pass to calculate FLOPs for inference-only workload (no backward pass)')
     return parser
 
 # calculates the flops of a model given its hparams
-def calc_params(args):
+def calc_flops(args):
     assert args.topk <= args.num_experts, "You cannot route to more experts than you have!"
     assert args.num_layers % args.expert_interval == 0, "Require for simplicity that we don't have hanging dense layers"
 
@@ -89,11 +97,12 @@ def calc_params(args):
     if args.infer:
         iter_factor = 1
 
+    # The factor of 2 from all these terms comes from the multiply + accumulate
     qkv_flops = int(iter_factor * 2 * (1 + 2 * args.kv_size_ratio) * args.num_layers * args.tokens * args.hidden_size * args.hidden_size)
     attention_matrix_flops = iter_factor * 2 * args.num_layers * args.tokens * args.sequence_length * args.hidden_size
     attention_over_values_flops = iter_factor * 2 * args.num_layers * args.tokens * args.sequence_length * args.hidden_size
     linear_projection_flops = iter_factor * 2 * args.num_layers * args.tokens * args.hidden_size * args.hidden_size
-    ffn_flops = iter_factor * 16 * args.num_layers * args.tokens * args.hidden_size * args.hidden_size
+    ffn_flops = iter_factor * 2 * args.num_mlp_linears * args.ffn_expansion_factor * args.num_layers * args.tokens * args.hidden_size * args.hidden_size
     if args.swiglu:
         ffn_flops = 3/2 * ffn_flops
     # no activation checkpointing for embeddings
@@ -126,4 +135,4 @@ if __name__ == "__main__":
     print('Example with GPT-3 175B: python calc_transformer_flops.py -l 96 -hs 12288')
     
     args = config_parser().parse_args()
-    calc_params(args)
+    calc_flops(args)

--- a/calc/calc_transformer_mem.py
+++ b/calc/calc_transformer_mem.py
@@ -77,6 +77,10 @@ def config_parser():
                         type=int,
                         default=4,
                         help='How much the MLP hidden size expands')
+    parser.add_argument("--num-mlp-linears", "-nl",
+                        type=int,
+                        default=2,
+                        help='How many linear layers per MLP block')
     # Inference settings
     parser.add_argument("--infer",
                         action="store_true",
@@ -130,7 +134,7 @@ def calc_mem(args):
     positional_params = args.hidden_size * args.sequence_length
     ln_params = 8 * args.hidden_size * args.num_layers + (2 * args.hidden_size)
     attention_params = int(2 * (1 + args.kv_size_ratio) * args.num_layers * args.hidden_size * args.hidden_size)
-    mlp_params = 2 * args.num_layers * args.hidden_size * args.ffn_expansion_factor * args.hidden_size
+    mlp_params = args.num_mlp_linears * args.num_layers * args.hidden_size * args.ffn_expansion_factor * args.hidden_size
     total_params = embed_params + positional_params + ln_params + attention_params + mlp_params
 
     # --- MODEL MEMORY ---


### PR DESCRIPTION
Addresses https://github.com/EleutherAI/cookbook/issues/36

Before: 
```
$ python calc/calc_transformer_mem.py --infer --high-prec-b
ytes-per-val 4 --low-prec-bytes-per-val 1 --num-gpus 2 --zero-stage 3 -ca -b 1 -s 1024 -v 152
064 -hs 8192 -a 64 -l 80 -kv 1 -ff 3

Calculating memory with training configuration: {'num_gpus': 2, 'tensor_parallel_size': 1, 'pipeline_parallel_size': 1, 'partition_activations': False, 'zero_stage': 3, 'zero_allgather_bucket_size': 500000000.0, 'zero3_max_live_params': 1000000000.0, 'checkpoint_activations': True, 'batch_size_per_gpu': 1, 'sequence_length': 1024, 'vocab_size': 152064, 'hidden_size': 8192, 'num_attention_heads': 64, 'num_layers': 80, 'ffn_expansion_factor': 3, 'num_mlp_linears': 2, 'infer': True, 'kv_size_ratio': 1.0, 'is_mixed_precision': True, 'high_prec_bytes_per_val': 4, 'low_prec_bytes_per_val': 1, 'bytes_per_grad_ele': 4, 'num_experts': 0, 'expert_parallelism': 1, 'misc_mem_gib': 0}

Number of Parameters: 56.19 B

*** Per-GPU Memory
Per-GPU Activation Memory: 0.14 GiB
Per-GPU Model Memory: 26.17 GiB
Per-GPU KV Cache Memory: 1.25 GiB

Per-GPU Memory Required for Inference: 27.56 GiB

*** Total GPU Memory for a Single Model Replica
Total Activation Memory: 0.14 GiB
Total Model Memory: 52.33 GiB
Total KV Cache Memory: 2.50 GiB

Total GPU Memory Required to Store a Complete Model Replica for Inference: 54.97 GiB
```


After:
```
$ python calc/calc_transformer_mem.py --infer --high-prec-bytes-per-val 4 --low-prec-bytes-per-val 1 -nl 3 --num-gpus 2 --zero-stage 3 -ca -b 1 -s 1024 
-v 152064 -hs 8192 -a 64 -l 80 -kv 1 -ff 3

Calculating memory with training configuration: {'num_gpus': 2, 'tensor_parallel_size': 1, 'pipeline_parallel_size': 1, 'partition_activations': False, 'zero_stage': 3, 'zero_allgather_bucket_size': 500000000.0, 'zero3_max_live_params': 1000000000.0, 'checkpoint_activations': True, 'batch_size_per_gpu': 1, 'sequence_length': 1024, 'vocab_size': 152064, 'hidden_size': 8192, 'num_attention_heads': 64, 'num_layers': 80, 'ffn_expansion_factor': 3, 'num_mlp_linears': 3, 'infer': True, 'kv_size_ratio': 1.0, 'is_mixed_precision': True, 'high_prec_bytes_per_val': 4, 'low_prec_bytes_per_val': 1, 'bytes_per_grad_ele': 4, 'num_experts': 0, 'expert_parallelism': 1, 'misc_mem_gib': 0}

Number of Parameters: 72.3 B

*** Per-GPU Memory
Per-GPU Activation Memory: 0.14 GiB
Per-GPU Model Memory: 33.67 GiB
Per-GPU KV Cache Memory: 1.25 GiB

Per-GPU Memory Required for Inference: 35.06 GiB

*** Total GPU Memory for a Single Model Replica
Total Activation Memory: 0.14 GiB
Total Model Memory: 67.33 GiB
Total KV Cache Memory: 2.50 GiB

Total GPU Memory Required to Store a Complete Model Replica for Inference: 69.97 GiB
```

Also cleaned up args indentation.