### PR TITLE
Add HuggingFace arg so that arch is automatic

### DIFF
--- a/calc/README.md
+++ b/calc/README.md
@@ -100,14 +100,16 @@ Example with pythia 6.9B: python calc_transformer_mem.py --num-layers=32 --seque
 Example with pythia 12B: python calc_transformer_mem.py --num-layers=36 --sequence-length=2048 --num-attention-heads=40 --hidden-size=5120 --batch-size-per-gpu=8 --checkpoint-activations --zero-stage=1 --partition-activations --pipeline-parallel-size=1 --tensor-parallel-size=4 --num-gpus=256
 Example with default 20B: python calc_transformer_mem.py --num-layers=44 --sequence-length=2048 --num-attention-heads=64 --hidden-size=6144 --batch-size-per-gpu=1 --checkpoint-activations --zero-stage=1 --partition-activations --pipeline-parallel-size=1 --tensor-parallel-size=1 --num-gpus=1
 
-usage: calc_transformer_mem.py [-h] [--num-gpus NUM_GPUS] [--tensor-parallel-size TENSOR_PARALLEL_SIZE] [--pipeline-parallel-size PIPELINE_PARALLEL_SIZE] [--partition-activations] [--zero-stage {0,1,2,3}] [--zero-allgather-bucket-size ZERO_ALLGATHER_BUCKET_SIZE]
-                               [--zero3-max-live-params ZERO3_MAX_LIVE_PARAMS] [--checkpoint-activations] [--batch-size-per-gpu BATCH_SIZE_PER_GPU] [--sequence-length SEQUENCE_LENGTH] [--vocab-size VOCAB_SIZE] [--hidden-size HIDDEN_SIZE]
-                               [--num-attention-heads NUM_ATTENTION_HEADS] [--num-layers NUM_LAYERS] [--ffn-expansion-factor FFN_EXPANSION_FACTOR] [--num-mlp-linears NUM_MLP_LINEARS] [--infer] [--kv-size-ratio KV_SIZE_RATIO] [--output-tokens OUTPUT_TOKENS]
-                               [--disable-mixed-precision] [--high-prec-bytes-per-val HIGH_PREC_BYTES_PER_VAL] [--low-prec-bytes-per-val LOW_PREC_BYTES_PER_VAL] [--bytes-per-grad-ele BYTES_PER_GRAD_ELE] [--num-experts NUM_EXPERTS]
+usage: calc_transformer_mem.py [-h] [--hf_model_name_or_path HF_MODEL_NAME_OR_PATH] [--num-gpus NUM_GPUS] [--tensor-parallel-size TENSOR_PARALLEL_SIZE] [--pipeline-parallel-size PIPELINE_PARALLEL_SIZE] [--partition-activations] [--zero-stage {0,1,2,3}]
+                               [--zero-allgather-bucket-size ZERO_ALLGATHER_BUCKET_SIZE] [--zero3-max-live-params ZERO3_MAX_LIVE_PARAMS] [--checkpoint-activations] [--batch-size-per-gpu BATCH_SIZE_PER_GPU] [--sequence-length SEQUENCE_LENGTH] [--vocab-size VOCAB_SIZE]
+                               [--hidden-size HIDDEN_SIZE] [--num-attention-heads NUM_ATTENTION_HEADS] [--num-layers NUM_LAYERS] [--ffn-expansion-factor FFN_EXPANSION_FACTOR] [--num-mlp-linears NUM_MLP_LINEARS] [--infer] [--kv-size-ratio KV_SIZE_RATIO]
+                               [--output-tokens OUTPUT_TOKENS] [--disable-mixed-precision] [--high-prec-bytes-per-val HIGH_PREC_BYTES_PER_VAL] [--low-prec-bytes-per-val LOW_PREC_BYTES_PER_VAL] [--bytes-per-grad-ele BYTES_PER_GRAD_ELE] [--num-experts NUM_EXPERTS]
                                [--expert-parallelism EXPERT_PARALLELISM] [--misc-mem-gib MISC_MEM_GIB]
 
 options:
   -h, --help            show this help message and exit
+  --hf_model_name_or_path HF_MODEL_NAME_OR_PATH
+                        Name of the HuggingFace Hub repository or the local file path for it
   --num-gpus NUM_GPUS   Number of GPUs used for training
   --tensor-parallel-size TENSOR_PARALLEL_SIZE, -tp TENSOR_PARALLEL_SIZE
                         Tensor parallel degree (1 if not used)

--- a/calc/calc_transformer_mem.py
+++ b/calc/calc_transformer_mem.py
@@ -3,6 +3,8 @@
 import argparse
 import math
 
+from transformers import AutoConfig
+
 # Helper function to pretty-print message sizes
 def convert_params(params):
     if params == 0:
@@ -16,6 +18,10 @@ def convert_params(params):
 def config_parser():
     parser = argparse.ArgumentParser()
     # Distributed Settings
+    parser.add_argument("--hf_model_name_or_path", 
+                        type=str, 
+                        default=None, 
+                        help="Name of the HuggingFace Hub respository or the local file path for it")
     parser.add_argument("--num-gpus",
                         type=int,
                         default=1,
@@ -126,6 +132,32 @@ def config_parser():
                         help='Miscellaneous memory overhead per GPU by DL framework(s), communication libraries, etc')
 
     return parser
+
+# TODO: A function that gets the HuggingFace Model config, takes the required values from it
+# Updates the args
+def get_hf_model_args(args):
+    # Check if the name is not None
+    # Check if it exists at all
+    if args.hf_model_name_or_path is not None:
+        try: 
+            config = AutoConfig.from_pretrained(args.hf_model_name_or_path)
+        except OSError:
+            print("Model Repository name or path not found. Are you sure it exists?")
+            print("Reverting with default values instead")
+            return args
+        
+        # Now that config has been retrieved, we update the args with the config values
+        # NOTE: Different Model configs have different nomenclature in HuggingFace, would need to support them individually
+
+        arch = config.architectures[0]
+        if 'phi' in arch.lower():
+            ... # Phi style nomenclature
+        elif 'llama' in arch.lower():
+            ... # llama style nomenclature
+        else:
+            ...
+
+    return args
 
 
 # Calculates the total memory necessary for model training or inference

--- a/calc/calc_transformer_mem.py
+++ b/calc/calc_transformer_mem.py
@@ -3,10 +3,13 @@
 import argparse
 import math
 
-from transformers import AutoConfig
 
-# Helper function to pretty-print message sizes
+### Begin Helper Functions ###
+
 def convert_params(params):
+    '''
+    Helper function to pretty-print message sizes
+    '''
     if params == 0:
         return "0"
     size_name = ("", "K", "M", "B", "T", "P", "E", "Z", "Y")
@@ -14,151 +17,6 @@ def convert_params(params):
     p = math.pow(1000, i)
     s = round(params / p, 2)
     return "%s %s" % (s, size_name[i])
-
-def config_parser():
-    parser = argparse.ArgumentParser()
-    # Distributed Settings
-    parser.add_argument("--hf_model_name_or_path", 
-                        type=str, 
-                        default=None, 
-                        help="Name of the HuggingFace Hub respository or the local file path for it")
-    parser.add_argument("--num-gpus",
-                        type=int,
-                        default=1,
-                        help='Number of GPUs used for training')
-    parser.add_argument("--tensor-parallel-size", "-tp",
-                        type=int,
-                        default=1,
-                        help='Tensor parallel degree (1 if not used)')
-    parser.add_argument("--pipeline-parallel-size", "-pp",
-                        type=int,
-                        default=1,
-                        help='Pipeline parallel degree (1 if not used)')
-    parser.add_argument("--partition-activations", "-pa",
-                        action="store_true",
-                        help='Whether we use ZeRO-R to partition activation memory across tensor-parallel degree')
-    parser.add_argument("--zero-stage", "-z",
-                        type=int,
-                        default=1,
-                        choices=[0,1,2,3],
-                        help='Stage of the ZeRO optimizer')
-    parser.add_argument("--zero-allgather-bucket-size", "-zbs",
-                        type=int,
-                        default=5e8,
-                        help='Size of allgather buckets used by ZeRO')
-    parser.add_argument("--zero3-max-live-params", "-zmlp",
-                        type=int,
-                        default=1e9,
-                        help='Maximum number of parameters ZeRO3 keeps in GPU memory')
-    # Training settings
-    parser.add_argument("--checkpoint-activations", "-ca",
-                        action="store_true",
-                        help='Whether Megatron-style activation checkpointing is being used')
-    parser.add_argument("--batch-size-per-gpu", "-b",
-                        type=int,
-                        default=1,
-                        help='Batch size per GPU')
-    parser.add_argument("--sequence-length", "-s",
-                        type=int,
-                        default=None,
-                        help='Sequence length used for training')
-    parser.add_argument("--vocab-size", "-v",
-                        type=int,
-                        default=None,
-                        help='How many tokens are in the embedding layer')
-    # Model settings
-    parser.add_argument("--hidden-size", "-hs",
-                        type=int,
-                        default=None,
-                        help='Dimension of the model\'s hidden size')
-    parser.add_argument("--num-attention-heads", "-a",
-                        type=int,
-                        default=None,
-                        help='Number of attention heads used in model')
-    parser.add_argument("--num-layers", "-l",
-                        type=int,
-                        default=None,
-                        help='Number of transformer layers used in model')
-    parser.add_argument("--ffn-expansion-factor", "-ff",
-                        type=int,
-                        default=None,
-                        help='How much the MLP hidden size expands')
-    parser.add_argument("--num-mlp-linears", "-nl",
-                        type=int,
-                        default=2,
-                        help='How many linear layers per MLP block')
-    # Inference settings
-    parser.add_argument("--infer",
-                        action="store_true",
-                        help="whether we're doing inference")
-    parser.add_argument("--kv-size-ratio", "-kv",
-                        type=float,
-                        default=1.0,
-                        help='Ratio of total query heads to key/value heads. 1.0 for MHA, 1/num_attention_heads for MQA.')
-    parser.add_argument("--output-tokens", "-o",
-                        type=int,
-                        default=1,
-                        help='Number of tokens to autoregressively generate.')
-    # Precision settings
-    parser.add_argument("--disable-mixed-precision",
-                        action="store_false",
-                        help='Disables mixed precision training',
-                        dest='is_mixed_precision')
-    parser.add_argument("--high-prec-bytes-per-val",
-                        type=int,
-                        default=4,
-                        help='The high-precision bytes per value (parameter, optimizer state, etc) in mixed precision')
-    parser.add_argument("--low-prec-bytes-per-val",
-                        type=int,
-                        default=2,
-                        help='The low-precision bytes per value (parameter, optimizer state, etc) in mixed precision')
-    parser.add_argument("--bytes-per-grad-ele",
-                        type=int,
-                        default=4,
-                        help='The precision of gradient elements as bytes per value')
-    # MoE Settings
-    parser.add_argument("--num-experts",
-                        type=int,
-                        default=0,
-                        help='Number of experts')
-    parser.add_argument("--expert-parallelism", "-ep",
-                        type=int,
-                        default=1,
-                        help='How many ways are the experts sharded across ranks')
-    # Miscellaneous memory (good for accounting for implementation-dependent fudge factors)
-    parser.add_argument("--misc-mem-gib",
-                        type=int,
-                        default=0,
-                        help='Miscellaneous memory overhead per GPU by DL framework(s), communication libraries, etc')
-
-    return parser
-
-DEFAULTS = {
-    "num_layers" : 44,
-    "sequence_length" : 2048,
-    "num_attention_heads" : 64,
-    "hidden_size" : 6144,
-    "ffn_expansion_factor" : 4,
-    "kv_size_ratio" : 1.0,
-    "vocab_size" : 51200,
-    "num_gpus" : 1,
-    "tensor_parallel_size" : 1,
-    "pipeline_parallel_size" : 1,
-    "partition_activations" : False,
-    "zero_stage" : 1,
-    "zero_allgather_bucket_size" : 5e8,
-    "zero3_max_live_params" : 1e9,
-    "checkpoint_activations" : False,
-    "batch_size_per_gpu" : 1,
-    "is_mixed_precision" : True,
-    "high_prec_bytes_per_val" : 4,
-    "low_prec_bytes_per_val" : 2,
-    "bytes_per_grad_ele" : 4,
-    "num_experts" : 0,
-    "expert_parallelism" : 1,
-    "infer" : False,
-    "misc_mem_gib" : 0
-}
 
 def set_defaults(args):
     '''
@@ -179,17 +37,24 @@ def set_if_none(args, key, config, config_key):
         print(f"overriding HF {config_key} config value ({config[config_key]}) with provided value ({getattr(args, key)})")
     return args
 
-# Updates the args with HuggingFace model config values
 def get_hf_model_args(args):
+    '''
+    Updates the args with HuggingFace model config values
+    '''
     # Check if the name is not None
     if args.hf_model_name_or_path is not None:
         try: 
+            from transformers import AutoConfig
             config = AutoConfig.from_pretrained(args.hf_model_name_or_path, 
                                                 trust_remote_code=True).to_dict()
-        except OSError:
-            print("Model Repository name or path not found. Are you sure it exists?")
-            print("Reverting with default values instead")
-            return args
+        except OSError as e:
+            print("An OSError has been raised. Commonly due to a model Repository name or path not found. Are you sure it exists?")
+            print('Full error: ')
+            raise e
+        except ImportError as e:
+            print('If you would like to calculate from a HF model, you must install HF transformers with pip install transformers')
+            print('Full error: ')
+            raise e
         
         # Now that config has been retrieved, we update the args with the config values
 
@@ -221,6 +86,168 @@ def get_hf_model_args(args):
 
     return args
 
+### End Helper Functions ###
+
+### Begin Argument Parsing ###
+
+def config_parser():
+    parser = argparse.ArgumentParser()
+    # HuggingFace Settings
+    parser.add_argument("--hf_model_name_or_path", 
+                        type=str, 
+                        default=None, 
+                        help="Name of the HuggingFace Hub repository or the local file path for it")
+    # Distributed Settings
+    parser.add_argument("--num-gpus",
+                        type=int,
+                        default=None,
+                        help='Number of GPUs used for training')
+    parser.add_argument("--tensor-parallel-size", "-tp",
+                        type=int,
+                        default=None,
+                        help='Tensor parallel degree (1 if not used)')
+    parser.add_argument("--pipeline-parallel-size", "-pp",
+                        type=int,
+                        default=None,
+                        help='Pipeline parallel degree (1 if not used)')
+    parser.add_argument("--partition-activations", "-pa",
+                        action="store_true",
+                        help='Whether we use ZeRO-R to partition activation memory across tensor-parallel degree')
+    parser.add_argument("--zero-stage", "-z",
+                        type=int,
+                        default=None,
+                        choices=[0,1,2,3],
+                        help='Stage of the ZeRO optimizer')
+    parser.add_argument("--zero-allgather-bucket-size", "-zbs",
+                        type=int,
+                        default=None,
+                        help='Size of allgather buckets used by ZeRO')
+    parser.add_argument("--zero3-max-live-params", "-zmlp",
+                        type=int,
+                        default=None,
+                        help='Maximum number of parameters ZeRO3 keeps in GPU memory')
+    # Training settings
+    parser.add_argument("--checkpoint-activations", "-ca",
+                        action="store_true",
+                        help='Whether Megatron-style activation checkpointing is being used')
+    parser.add_argument("--batch-size-per-gpu", "-b",
+                        type=int,
+                        default=None,
+                        help='Batch size per GPU')
+    parser.add_argument("--sequence-length", "-s",
+                        type=int,
+                        default=None,
+                        help='Sequence length used for training')
+    parser.add_argument("--vocab-size", "-v",
+                        type=int,
+                        default=None,
+                        help='How many tokens are in the embedding layer')
+    # Model settings
+    parser.add_argument("--hidden-size", "-hs",
+                        type=int,
+                        default=None,
+                        help='Dimension of the model\'s hidden size')
+    parser.add_argument("--num-attention-heads", "-a",
+                        type=int,
+                        default=None,
+                        help='Number of attention heads used in model')
+    parser.add_argument("--num-layers", "-l",
+                        type=int,
+                        default=None,
+                        help='Number of transformer layers used in model')
+    parser.add_argument("--ffn-expansion-factor", "-ff",
+                        type=int,
+                        default=None,
+                        help='How much the MLP hidden size expands')
+    parser.add_argument("--num-mlp-linears", "-nl",
+                        type=int,
+                        default=None,
+                        help='How many linear layers per MLP block')
+    # Inference settings
+    parser.add_argument("--infer",
+                        action="store_true",
+                        help="whether we're doing inference")
+    parser.add_argument("--kv-size-ratio", "-kv",
+                        type=float,
+                        default=None,
+                        help='Ratio of total query heads to key/value heads. 1.0 for MHA, 1/num_attention_heads for MQA.')
+    parser.add_argument("--output-tokens", "-o",
+                        type=int,
+                        default=None,
+                        help='Number of tokens to autoregressively generate.')
+    # Precision settings
+    parser.add_argument("--disable-mixed-precision",
+                        action="store_false",
+                        help='Disables mixed precision training',
+                        dest='is_mixed_precision')
+    parser.add_argument("--high-prec-bytes-per-val",
+                        type=int,
+                        default=None,
+                        help='The high-precision bytes per value (parameter, optimizer state, etc) in mixed precision')
+    parser.add_argument("--low-prec-bytes-per-val",
+                        type=int,
+                        default=None,
+                        help='The low-precision bytes per value (parameter, optimizer state, etc) in mixed precision')
+    parser.add_argument("--bytes-per-grad-ele",
+                        type=int,
+                        default=None,
+                        help='The precision of gradient elements as bytes per value')
+    # MoE Settings
+    parser.add_argument("--num-experts",
+                        type=int,
+                        default=None,
+                        help='Number of experts')
+    parser.add_argument("--expert-parallelism", "-ep",
+                        type=int,
+                        default=None,
+                        help='How many ways are the experts sharded across ranks')
+    # Miscellaneous memory (good for accounting for implementation-dependent fudge factors)
+    parser.add_argument("--misc-mem-gib",
+                        type=int,
+                        default=None,
+                        help='Miscellaneous memory overhead per GPU by DL framework(s), communication libraries, etc')
+
+    return parser
+
+DEFAULTS = {
+    # Distributed Settings
+    "num_gpus" : 1,
+    "tensor_parallel_size" : 1,
+    "pipeline_parallel_size" : 1,
+    "partition_activations" : False,
+    "zero_stage" : 1,
+    "zero_allgather_bucket_size" : 5e8,
+    "zero3_max_live_params" : 1e9,
+    # Training Settings
+    "checkpoint_activations" : False,
+    "batch_size_per_gpu" : 1,
+    "sequence_length" : 2048,
+    "vocab_size" : 51200,
+    # Model Settings
+    "hidden_size" : 6144,
+    "num_attention_heads" : 64,
+    "num_layers" : 44,
+    "ffn_expansion_factor" : 4,
+    "num_mlp_linears": 2,
+    # Inference Settings
+    "infer" : False,
+    "kv_size_ratio" : 1.0,
+    "output_tokens" : 1,
+    # Precision Settings
+    "is_mixed_precision" : True,
+    "high_prec_bytes_per_val" : 4,
+    "low_prec_bytes_per_val" : 2,
+    "bytes_per_grad_ele" : 4,
+    # MoE Settings
+    "num_experts" : 0,
+    "expert_parallelism" : 1,
+    # Miscellaneous Memory
+    "misc_mem_gib" : 0
+}
+
+### End Argument Parsing ###
+
+### Begin Memory Calculation ###
 
 # Calculates the total memory necessary for model training or inference
 def calc_mem(args):
@@ -383,6 +410,8 @@ def calc_mem(args):
         print(f'\nTotal GPU Memory Required to Store a Complete Model Replica for Inference: {single_replica_mem_gib:.2f} GiB')
     else:
         print(f'\nTotal GPU Memory Required to Store a Complete Model Replica for Training: {single_replica_mem_gib:.2f} GiB')
+
+### End Memory Calculation ###
 
 if __name__ == "__main__":
     print('\nExample with pythia 6.9B: python calc_transformer_mem.py --num-layers=32 --sequence-length=2048 --num-attention-heads=32 --hidden-size=4096 --batch-size-per-gpu=8 --checkpoint-activations --zero-stage=1 --partition-activations --pipeline-parallel-size=1 --tensor-parallel-size=2 --num-gpus=128')

--- a/calc/calc_transformer_mem.py
+++ b/calc/calc_transformer_mem.py
@@ -1,4 +1,4 @@
-# By Quentin Anthony and Hailey Schoelkopf
+# By Quentin Anthony, Hailey Schoelkopf, Bhavnick Minhas
 
 import argparse
 import math

--- a/calc/calc_transformer_mem.py
+++ b/calc/calc_transformer_mem.py
@@ -133,11 +133,9 @@ def config_parser():
 
     return parser
 
-# TODO: A function that gets the HuggingFace Model config, takes the required values from it
-# Updates the args
+# Updates the args with HuggingFace model config values
 def get_hf_model_args(args):
     # Check if the name is not None
-    # Check if it exists at all
     if args.hf_model_name_or_path is not None:
         try: 
             config = AutoConfig.from_pretrained(args.hf_model_name_or_path, 
@@ -148,7 +146,6 @@ def get_hf_model_args(args):
             return args
         
         # Now that config has been retrieved, we update the args with the config values
-        # NOTE: Different Model configs have different nomenclature in HuggingFace, would need to support them individually
 
         arch = config['model_type']
 

--- a/calc/calc_transformer_mem.py
+++ b/calc/calc_transformer_mem.py
@@ -140,7 +140,8 @@ def get_hf_model_args(args):
     # Check if it exists at all
     if args.hf_model_name_or_path is not None:
         try: 
-            config = AutoConfig.from_pretrained(args.hf_model_name_or_path)
+            config = AutoConfig.from_pretrained(args.hf_model_name_or_path, 
+                                                trust_remote_code=True).to_dict()
         except OSError:
             print("Model Repository name or path not found. Are you sure it exists?")
             print("Reverting with default values instead")
@@ -149,19 +150,31 @@ def get_hf_model_args(args):
         # Now that config has been retrieved, we update the args with the config values
         # NOTE: Different Model configs have different nomenclature in HuggingFace, would need to support them individually
 
-        arch = config.architectures[0]
-        if 'phi' in arch.lower():
-            ... # Phi style nomenclature
-        elif 'llama' in arch.lower():
-            ... # llama style nomenclature
-        else:
-            ...
+        arch = config['model_type']
 
+       # Seperate handling for gpt2 because they named everything differently 
+        if arch.lower()=='gpt2': 
+            args.num_layers = config.get("n_layer", args.num_layers) # Set Phi Default
+            args.num_attention_heads = config.get("n_head", args.num_attention_heads)
+            args.hidden_size = config.get("n_embd", args.hidden_size)
+            args.vocab_size = config.get("vocab_size", args.vocab_size)
+
+        else: 
+            args.num_layers = config.get("num_hidden_layers", args.num_layers) # Set Phi Default
+            args.num_attention_heads = config.get("num_attention_heads", args.num_attention_heads)
+            args.hidden_size = config.get("hidden_size", args.hidden_size)
+            args.ffn_expansion_factor = config.get("intermediate_size")/ args.hidden_size
+            args.kv_size_ratio = config.get("num_key_value_heads", args.num_attention_heads)/ args.num_attention_heads
+            args.vocab_size = config.get("vocab_size", args.vocab_size)
+        
     return args
 
 
 # Calculates the total memory necessary for model training or inference
 def calc_mem(args):
+
+    # set the hf_args if hf model is provided
+    args = get_hf_model_args(args)
 
     dp_degree = args.num_gpus / (args.tensor_parallel_size * args.pipeline_parallel_size)
 


### PR DESCRIPTION
This pull request is made to work on adding automated parameter calculations for all hugging face models. 

Expected Behaviour:
```python
python transformer_mem.py --hf_model_name_or_path meta-llama/Llama-2-7b-hf --num-gpus 8 --zero-stage 3 --batch-size-per-gpu 2 --sequence-length 4096
```

Ref: [ #1 ] 